### PR TITLE
Enforce non_null message and message list

### DIFF
--- a/lib/absinthe_error_payload/payload.ex
+++ b/lib/absinthe_error_payload/payload.ex
@@ -122,7 +122,7 @@ defmodule AbsintheErrorPayload.Payload do
     quote location: :keep do
       object unquote(payload_name) do
         field(:successful, non_null(:boolean), description: "Indicates if the mutation completed successfully or not. ")
-        field(:messages, list_of(:validation_message), description: "A list of failed validations. May be blank or null if mutation succeeded.")
+        field(:messages, non_null(list_of(non_null(:validation_message))), description: "A list of failed validations. May be blank or null if mutation succeeded.")
         field(:result, unquote(result_object_name), description: "The object created/updated/deleted by the mutation. May be null if mutation failed.")
       end
     end


### PR DESCRIPTION
## 📖 Description and reason

The messages list included in the payload object was nullable, and each message in the list was also nullable. This makes the responses more ambiguous and is more work for the consuming clients.

## 👷 Work done

#### Additional notes

Relevant discussion: https://github.com/Ethelo/kronky/issues/13

All existing tests continue to pass.

## 🎉 Result

The payload messages list and the messages themselves cannot be null. Having no errors is represented by an empty list.